### PR TITLE
changed href computation (fix #66)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ BugReports: https://github.com/gesistsa/adaR/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 LinkingTo: 
     Rcpp
 Imports: 

--- a/R/get.R
+++ b/R/get.R
@@ -29,7 +29,11 @@
 #' ada_get_port(urls)
 #' @export
 ada_get_href <- function(url, decode = TRUE) {
-    .get(url, decode, Rcpp_ada_get_href)
+    if (decode) {
+        return(url_decode2(url))
+    } else {
+        return(url)
+    }
 }
 
 #' @rdname ada_get_href

--- a/src/adaR.cpp
+++ b/src/adaR.cpp
@@ -12,6 +12,12 @@ std::string charsub(const ada_string stringi) {
   return output2;
 }
 
+std::string ada_string_to_std_string(const ada_string stringi) {
+  std::string_view output(stringi.data, stringi.length);
+  std::string output2 = {output.begin(), output.end()};
+  return output2;
+}
+
 // [[Rcpp::export]]
 DataFrame Rcpp_ada_parse(const CharacterVector& input_vec, bool decode) {
   unsigned int n = input_vec.length();
@@ -30,7 +36,7 @@ DataFrame Rcpp_ada_parse(const CharacterVector& input_vec, bool decode) {
     std::string_view input(s.get_cstring());
     ada_url url = ada_parse(input.data(), input.length());
     if (ada_is_valid(url)) {
-      href[i] = charsub(ada_get_href(url));
+      href[i] = s;  // charsub(ada_get_href(url));
       protocol[i] = charsub(ada_get_protocol(url));
       username[i] = charsub(ada_get_username(url));
       password[i] = charsub(ada_get_password(url));
@@ -155,7 +161,7 @@ CharacterVector Rcpp_ada_get(const CharacterVector& url_vec,
   return (out);
 }
 
-// [[Rcpp::export]]
+//[[Rcpp::export]]
 CharacterVector Rcpp_ada_get_href(const CharacterVector& url_vec, bool decode) {
   return Rcpp_ada_get(url_vec, &ada_get_href, decode);
 }
@@ -229,7 +235,7 @@ CharacterVector Rcpp_ada_set(
       out[i] = NA_STRING;
     } else {
       func(url, replace.data(), replace.length());
-      out[i] = charsub(ada_get_href(url));
+      out[i] = ada_string_to_std_string(ada_get_href(url));
     }
     ada_free(url);
   }
@@ -316,7 +322,7 @@ CharacterVector Rcpp_ada_clear(const CharacterVector& url_vec,
       out[i] = NA_STRING;
     } else {
       func(url);
-      out[i] = charsub(ada_get_href(url));
+      out[i] = ada_string_to_std_string(ada_get_href(url));
     }
     ada_free(url);
   }

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -127,3 +127,16 @@ test_that("domain with path #51", {
     expect_equal(ada_get_domain(url), "example.org")
     expect_equal(ada_get_domain(corner_cases), corner_domains)
 })
+
+test_that("href fix #66", {
+    examples <- c(
+        "http://xn--53-6kcainf4buoffq.xn--p1ai/pood/junior-electrical-engineer-jobs-remote.html",
+        "http://xn--80abb0biooohbv.xn--p1ai/",
+        "http://xn--alicantesueo-khb.com/insomnio",
+        "https://normal-url.com/this-path-will-be-fine",
+        "http://xn--53-6kcainf4buoffq.xn--p1ai/this-path-will-not-be-fine"
+    )
+    pathnames <- ada_get_pathname(examples, decode = FALSE)
+    result_pathnames <- ada_set_pathname(examples, pathnames, decode = FALSE)
+    expect_true(all(examples == result_pathnames))
+})

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -1,39 +1,39 @@
 test_that("works with standard url", {
-  res <- ada_url_parse("https://www.google.de")
-  expect_equal(res[["href"]], "https://www.google.de/")
-  expect_equal(res[["host"]], "www.google.de")
+    res <- ada_url_parse("https://www.google.de/")
+    expect_equal(res[["href"]], "https://www.google.de/")
+    expect_equal(res[["host"]], "www.google.de")
 })
 
 test_that("works with complex url", {
-  res <- ada_url_parse("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag")
-  expect_equal(res[["username"]], "user_1")
-  expect_equal(res[["password"]], "password_1")
-  expect_equal(res[["host"]], "example.org:8080")
-  expect_equal(res[["hostname"]], "example.org")
-  expect_equal(res[["port"]], "8080")
-  expect_equal(res[["pathname"]], "/api")
-  expect_equal(res[["search"]], "?q=1")
-  expect_equal(res[["hash"]], "#frag")
+    res <- ada_url_parse("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag")
+    expect_equal(res[["username"]], "user_1")
+    expect_equal(res[["password"]], "password_1")
+    expect_equal(res[["host"]], "example.org:8080")
+    expect_equal(res[["hostname"]], "example.org")
+    expect_equal(res[["port"]], "8080")
+    expect_equal(res[["pathname"]], "/api")
+    expect_equal(res[["search"]], "?q=1")
+    expect_equal(res[["hash"]], "#frag")
 })
 
 test_that("works with utf8", {
-  res <- ada_url_parse("https://www.hk01.com/zone/1/\u6e2f\u805e")
-  expect_equal(res[["pathname"]], "/zone/1/\u6e2f\u805e")
-  res <- ada_url_parse("http://www.m\u00fcller.de")
-  expect_equal(res[["host"]], "www.m\u00fcller.de")
-  res <- ada_url_parse("https://\u4e2d\u56fd\u79fb\u52a8.\u4e2d\u56fd")
-  expect_equal(res$href[1], "https://xn--fiq02ib9d179b.xn--fiqs8s/")
-  expect_equal(res$host[1], "\u4e2d\u56fd\u79fb\u52a8.\u4e2d\u56fd")
+    res <- ada_url_parse("https://www.hk01.com/zone/1/\u6e2f\u805e")
+    expect_equal(res[["pathname"]], "/zone/1/\u6e2f\u805e")
+    res <- ada_url_parse("http://www.m\u00fcller.de")
+    expect_equal(res[["host"]], "www.m\u00fcller.de")
+    res <- ada_url_parse("https://\u4e2d\u56fd\u79fb\u52a8.\u4e2d\u56fd")
+    expect_equal(res$href[1], "https://\u4e2d\u56fd\u79fb\u52a8.\u4e2d\u56fd")
+    expect_equal(res$host[1], "\u4e2d\u56fd\u79fb\u52a8.\u4e2d\u56fd")
 })
 
 test_that("URLdecode optional #5", {
-  expect_equal(ada_url_parse("https://www.google.co.jp/search?q=\u30c9\u30a4\u30c4")$search, "?q=\u30c9\u30a4\u30c4") ## default TRUE
-  expect_equal(ada_url_parse("https://www.google.co.jp/search?q=\u30c9\u30a4\u30c4", decode = FALSE)$search, "?q=%E3%83%89%E3%82%A4%E3%83%84")
+    expect_equal(ada_url_parse("https://www.google.co.jp/search?q=\u30c9\u30a4\u30c4")$search, "?q=\u30c9\u30a4\u30c4") ## default TRUE
+    expect_equal(ada_url_parse("https://www.google.co.jp/search?q=\u30c9\u30a4\u30c4", decode = FALSE)$search, "?q=%E3%83%89%E3%82%A4%E3%83%84")
 })
 
 test_that("multiple urls", {
-  urls <- rep("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag", 5)
-  expect_equal(nrow(ada_url_parse(urls)), 5L)
+    urls <- rep("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag", 5)
+    expect_equal(nrow(ada_url_parse(urls)), 5L)
 })
 
 test_that("corner cases", {


### PR DESCRIPTION
@chainsawriot can I get your opinion again?
What is your take on the failing test?
```
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-get.R:3:5'): all get functions work ──────────────────────────
ada_get_href(url) (`actual`) not equal to "https://user_1:password_1@example.org:8080/api?q=1#frag" (`expected`).

`actual`:   "https://user_1:password_1@example.org:8080/dir/../api?q=1#frag"
`expected`: "https://user_1:password_1@example.org:8080/api?q=1#frag" 
```