### PR TITLE
Improve ada_url_parse performance (fix #73)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: adaR
 Title: A Fast 'WHATWG' Compliant URL Parser
-Version: 0.3.3
+Version: 0.3.3.9999
 Authors@R: 
     c(person("David", "Schoch", , "david@schochastics.net", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2952-4812")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# adaR 0.3.3.9999
+
+* improved ada_url_parse performance(#73)
+
 # adaR 0.3.3
 
 * * bumped ada-url to 2.9.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -94,7 +94,7 @@ practical circumstances.
 bench::mark(
     ada = ada_url_parse("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag", decode = FALSE),
     urltools = urltools::url_parse("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag"),
-    iterations = 1, check = FALSE
+    check = FALSE
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ practical circumstances.
 bench::mark(
     ada = ada_url_parse("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag", decode = FALSE),
     urltools = urltools::url_parse("https://user_1:password_1@example.org:8080/dir/../api?q=1#frag"),
-    iterations = 1, check = FALSE
+    check = FALSE
 )
 #> # A tibble: 2 × 6
 #>   expression      min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-#> 1 ada          1.24ms   1.24ms      806.        0B        0
-#> 2 urltools    812.7µs  812.7µs     1230.        0B        0
+#> 1 ada          2.83µs   3.24µs   286849.        0B     28.7
+#> 2 urltools   123.41µs 134.36µs     7277.        0B     36.8
 ```
 
 For further benchmark results, see `benchmark.md` in `data_raw`.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -11,7 +11,7 @@ Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
 #endif
 
 // Rcpp_ada_parse
-DataFrame Rcpp_ada_parse(const CharacterVector& input_vec, bool decode);
+List Rcpp_ada_parse(const CharacterVector& input_vec, bool decode);
 RcppExport SEXP _adaR_Rcpp_ada_parse(SEXP input_vecSEXP, SEXP decodeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;


### PR DESCRIPTION
This PR improves `ada_url_parse` performance by returning a `Rcpp::List` from `Rcpp_ada_parse` with dataframe attributes assigned.

fixes: #73